### PR TITLE
Missing definition of child node as saddle owner, very rare case

### DIFF
--- a/code/divide_tree.cpp
+++ b/code/divide_tree.cpp
@@ -753,6 +753,7 @@ void DivideTree::removePeak(int peakId, int neighborPeakId) {
           if (elevation > highestSaddleElevation) {
             highestSaddleElevation = elevation;
             neighborPeakId = nodeId;
+            saddleOwnerIsChild = true;
           }
         }
       }


### PR DESCRIPTION
When merging tiles, sometimes I ran into infinite loops. Changing the merging order (i.e. iterating the tiles to merge over latitude or over longitude first) sometimes solved the issue but then the merge could stuck during another tile merge. The infinite loop was due to a node being assigned himself as parent. 

I found it happened inside the [rare case](https://github.com/oargudo/mountains/blob/db9f04089f71848d7a6e12e93345f118d6b6a182/code/divide_tree.cpp#L736-L759) mentioned in the comments of removing a peak that is not directly connected to neighbor. The variable `saddleOwnerIsChild` was not being set to true inside the loop searching for a saddle from a child node and retained the value [false from line 746](https://github.com/oargudo/mountains/blob/db9f04089f71848d7a6e12e93345f118d6b6a182/code/divide_tree.cpp#L746) if the peak being removed had a parent.