### PR TITLE
Tool to compute prominence parents from divide trees.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,28 @@ latitude,longitude,elevation in feet,key saddle latitude,key saddle longitude,pr
 
 A zip file with our prominence results for the world is [here](https://drive.google.com/file/d/0B3icWNhBosDXZmlEWldSLWVGOE0/view?usp=sharing).
 
+## Prominence parents
+
+Given a divide tree, it's possible to compute each peak's *prominence parent*, that is, the first more prominent peak that's encountered
+while walking from a peak, then to its key saddle, and then up the ridge up the other side.
+
+```
+Usage:
+  compute_parents divide_tree.dvt output_file
+
+  Options:
+  -m min_prominence Minimum prominence threshold for output, default = 300ft
+```
+
+The input divide tree must be free of runoffs (see the options to ```merge_divide_trees```).  The output will list a peak and its prominence
+parent on each line.  Landmass high points (where the prominence is equal to the elevation) are not included.  Their key saddles are the ocean,
+and there isn't a well-defined way to connect such peaks to other land masses through the divide tree.
+
 ## Anti-prominence
 
 The "anti-prominence" of low points can be computed by the same algorithm, simply by changing
 the sign of the elevation values.  This can be done by giving the -a option to the 
-"prominence" command.  Then, at the final stage of merging (with the -f flag), add the -a option 
+```prominence``` command.  Then, at the final stage of merging (with the -f flag), add the -a option 
 again to flip the elevation values back to positive.
 
 ## More information

--- a/code/Makefile
+++ b/code/Makefile
@@ -106,9 +106,19 @@ FILTER_POINTS_OBJS = \
 	$(OUTDIR)/filter_points.o \
 	$(POINTLIB) \
 
+COMPUTE_PARENTS_OBJS = \
+	$(OUTDIR)/coordinate_system.o \
+	$(OUTDIR)/divide_tree.o \
+	$(OUTDIR)/easylogging++.o \
+	$(OUTDIR)/island_tree.o \
+	$(OUTDIR)/kml_writer.o \
+	$(OUTDIR)/line_tree.o \
+	$(OUTDIR)/compute_parents.o \
+	$(POINTLIB) \
+
 
 all : makedirs $(OUTDIR)/isolation $(OUTDIR)/prominence $(OUTDIR)/merge_divide_trees \
-	 $(OUTDIR)/filter_points
+	 $(OUTDIR)/filter_points $(OUTDIR)/compute_parents
 
 $(POINTLIB) : $(POINTLIB_OBJS)
 	$(AR) $@ $^ 
@@ -123,6 +133,9 @@ $(OUTDIR)/merge_divide_trees: $(MERGE_DIVIDE_TREES_OBJS)
 	$(LINK) $^ -o $@ $(LIBS) $(LINKFLAGS)
 
 $(OUTDIR)/filter_points: $(FILTER_POINTS_OBJS)
+	$(LINK) $^ $(LIBS) -o $@ $(LINKFLAGS)
+
+$(OUTDIR)/compute_parents: $(COMPUTE_PARENTS_OBJS)
 	$(LINK) $^ $(LIBS) -o $@ $(LINKFLAGS)
 
 $(OUTDIR)/%.o : $(SOURCEDIR)/%.cpp
@@ -147,6 +160,8 @@ depend:
 
 # DO NOT DELETE
 
+debug/compute_parents.o: divide_tree.h coordinate_system.h primitives.h
+debug/compute_parents.o: latlng.h island_tree.h line_tree.h easylogging++.h
 debug/coordinate_system.o: coordinate_system.h primitives.h latlng.h
 debug/divide_tree.o: divide_tree.h coordinate_system.h primitives.h latlng.h
 debug/divide_tree.o: easylogging++.h island_tree.h kml_writer.h line_tree.h
@@ -177,6 +192,9 @@ debug/line_tree.o: line_tree.h primitives.h divide_tree.h coordinate_system.h
 debug/line_tree.o: latlng.h easylogging++.h
 debug/merge_divide_trees.o: divide_tree.h coordinate_system.h primitives.h
 debug/merge_divide_trees.o: latlng.h island_tree.h easylogging++.h
+debug/multi_source_loading_policy.o: multi_source_loading_policy.h
+debug/multi_source_loading_policy.o: tile_loading_policy.h tile.h
+debug/multi_source_loading_policy.o: primitives.h latlng.h
 debug/peak_finder.o: peak_finder.h tile.h primitives.h latlng.h
 debug/peakbagger_collection.o: peakbagger_collection.h peakbagger_point.h
 debug/peakbagger_collection.o: point.h quadtree.h

--- a/code/compute_parents.cpp
+++ b/code/compute_parents.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
 
   // Divide tree should be a "finalized" one with no runoffs.  We
   // don't handle runoffs in this calculation.
-  if (!divide_tree->runoffs().empty()) {
+  if (!divideTree->runoffs().empty()) {
     LOG(ERROR) << "Provide a finalized divide tree that has had all runoffs removed\n"
                << "(the -f option to merge_divide_trees)";
     return 1;

--- a/code/compute_parents.cpp
+++ b/code/compute_parents.cpp
@@ -1,0 +1,152 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2022 Andrew Kirmse
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// A tool to compute prominence parents from a divide tree.
+
+#include "divide_tree.h"
+#include "island_tree.h"
+#include "line_tree.h"
+#ifdef PLATFORM_LINUX
+#include <unistd.h>
+#endif
+#ifdef PLATFORM_WINDOWS
+#include "getopt-win.h"
+#endif
+
+#include "easylogging++.h"
+
+INITIALIZE_EASYLOGGINGPP
+
+using std::string;
+using std::vector;
+
+static void usage() {
+  printf("Usage:\n");
+  printf("  compute_parents divide_tree.dvt output_file\n");
+  printf("\n");
+  printf("  Options:\n");
+  printf("  -m min_prominence Minimum prominence threshold for output, default = 300ft\n");
+  exit(1);
+}
+
+int main(int argc, char **argv) {
+  int minProminence = 300;
+
+  // Parse options
+  START_EASYLOGGINGPP(argc, argv);
+
+  int ch;
+  while ((ch = getopt(argc, argv, "m:")) != -1) {
+    switch (ch) {
+    case 'm':
+      minProminence = static_cast<int>(atoi(optarg));
+      break;
+    }
+  }
+
+  argc -= optind;
+  argv += optind;
+  if (argc < 2) {
+    usage();
+  }
+
+  // Load divide tree
+  string inputFilename = argv[0];
+  string outputFilename = argv[1];
+  VLOG(1) << "Loading tree from " << inputFilename;
+  DivideTree *divideTree = DivideTree::readFromFile(inputFilename);
+  if (divideTree == nullptr) {
+    LOG(ERROR) << "Failed to load divide tree from " << inputFilename;
+    return 1;
+  }
+
+  // Divide tree should be a "finalized" one with no runoffs.  We
+  // don't handle runoffs in this calculation.
+  if (!divide_tree->runoffs().empty()) {
+    LOG(ERROR) << "Provide a finalized divide tree that has had all runoffs removed\n"
+               << "(the -f option to merge_divide_trees)";
+    return 1;
+  }
+  
+  // Build island tree to get prominence values
+  IslandTree *islandTree = new IslandTree(*divideTree);
+  islandTree->build();
+
+  // Build line parent tree
+  LineTree *lineTree = new LineTree(*divideTree);
+  lineTree->build();
+
+  FILE *file = fopen(outputFilename.c_str(), "wb");
+  const CoordinateSystem &coords = divideTree->coordinateSystem();
+  const vector<DivideTree::Node> &divideNodes = divideTree->nodes();
+  const vector<IslandTree::Node> &islandNodes = islandTree->nodes();
+  const vector<LineTree::Node> &lineNodes = lineTree->nodes();
+  const vector<Peak> &peaks = divideTree->peaks();
+  for (int i = 1; i < (int) divideNodes.size(); ++i) {
+    auto prom = islandNodes[i].prominence;
+    // Skip dinky peaks
+    if (prom < minProminence) {
+      continue;
+    }
+
+    auto &childPeak = peaks[i - 1];
+    LatLng childPos = coords.getLatLng(childPeak.location);
+
+    // No output for landmass high points
+    if (prom == childPeak.elevation) {
+      continue;
+    }
+    
+    VLOG(3) << "Considering peak " <<
+        childPos.latitude() << "," << childPos.longitude() << ",P=" << prom;
+
+    // Walk up line tree, looking for first peak with higher prominence.
+    // (Prominence values are stored in island tree.)
+    int parentId = lineNodes[i].parentId;
+    while (parentId != DivideTree::Node::Null) {
+      auto parentProm = islandNodes[parentId].prominence;
+      if (parentProm > prom) {
+        auto &parentPeak = peaks[parentId - 1];
+        LatLng parentPos = coords.getLatLng(parentPeak.location);
+        fprintf(file, "%.4f,%.4f,%d,%.4f,%.4f,%d\n",
+                childPos.latitude(), childPos.longitude(), prom,
+                parentPos.latitude(), parentPos.longitude(), parentProm);
+        break;
+      }
+      
+      parentId = lineNodes[parentId].parentId;
+    }
+    
+    if (parentId == DivideTree::Node::Null) {
+      VLOG(2) << "No prominence parent for peak " <<
+        childPos.latitude() << "," << childPos.longitude() << ",P=" << prom;
+    }
+  }
+  
+  delete islandTree;
+  delete lineTree;
+  delete divideTree;
+  
+  return 0;
+}

--- a/code/easylogging++.cc
+++ b/code/easylogging++.cc
@@ -1901,7 +1901,7 @@ Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
     logger_->m_logBuilder = m_defaultLogBuilder;
     registerNew(id, logger_);
     LoggerRegistrationCallback* callback = nullptr;
-    for (const std::pair<std::string, base::type::LoggerRegistrationCallbackPtr>& h
+    for (const std::pair<const std::string, base::type::LoggerRegistrationCallbackPtr>& h
          : m_loggerRegistrationCallbacks) {
       callback = h.second.get();
       if (callback != nullptr && callback->enabled()) {
@@ -2485,7 +2485,7 @@ void LogDispatcher::dispatch(void) {
   }
   LogDispatchCallback* callback = nullptr;
   LogDispatchData data;
-  for (const std::pair<std::string, base::type::LogDispatchCallbackPtr>& h
+  for (const std::pair<const std::string, base::type::LogDispatchCallbackPtr>& h
        : ELPP->m_logDispatchCallbacks) {
     callback = h.second.get();
     if (callback != nullptr && callback->enabled()) {

--- a/code/line_tree.h
+++ b/code/line_tree.h
@@ -42,15 +42,6 @@
 
 class LineTree {
 public:
-  explicit LineTree(const DivideTree &divideTree);
-
-  void build();
-
-  // Return true if the saddle has at least the given minimum
-  // prominence.
-  bool saddleHasMinProminence(int saddleId, Elevation minProminence);
-
-private:
   struct Node {
     int parentId;
     int saddleId;  // Saddle between us and line tree parent (not divide tree parent)
@@ -62,6 +53,19 @@ private:
     static const int Null = -1;
   };
 
+  explicit LineTree(const DivideTree &divideTree);
+
+  void build();
+
+  // Return true if the saddle has at least the given minimum
+  // prominence.
+  bool saddleHasMinProminence(int saddleId, Elevation minProminence);
+
+  bool writeToFile(const std::string &filename) const;
+
+  const std::vector<Node> &nodes() const;
+
+private:
   struct SaddleInfo {
     // Upper bound on saddle's prominence (including the possibility
     // of going off the map through a runoff).

--- a/code/makefile.win
+++ b/code/makefile.win
@@ -11,7 +11,7 @@ CP = copy
 RM = del /q
 RMDIR = rmdir
 MV = rename
-MKDIR = mkdir -p
+MKDIR = mkdir
 
 SOURCEDIR = .
 
@@ -116,10 +116,21 @@ FILTER_POINTS_OBJS = \
 	$(OUTDIR)/filter_points.obj \
 	$(POINTLIB) \
 
+COMPUTE_PARENTS_OBJS = \
+	$(OUTDIR)/coordinate_system.obj \
+	$(OUTDIR)/divide_tree.obj \
+	$(OUTDIR)/easylogging++.obj \
+	$(OUTDIR)/island_tree.obj \
+	$(OUTDIR)/kml_writer.obj \
+	$(OUTDIR)/line_tree.obj \
+	$(OUTDIR)/compute_parents.obj \
+	$(POINTLIB) \
+
 all : makedirs \
 	$(OUTDIR)/isolation.exe \
 	$(OUTDIR)/prominence.exe $(OUTDIR)/merge_divide_trees.exe \
 	$(OUTDIR)/filter_points.exe \
+	$(OUTDIR)/compute_parents.exe \
 
 $(POINTLIB): $(POINTLIB_OBJS)
 	$(AR) /OUT:$@ $**
@@ -134,6 +145,9 @@ $(OUTDIR)/merge_divide_trees.exe: $(MERGE_DIVIDE_TREES_OBJS)
 	$(LINK) $** -OUT:$@ $(LIBS) $(LINKFLAGS)
 
 $(OUTDIR)/filter_points.exe: $(FILTER_POINTS_OBJS)
+	$(LINK) $** -OUT:$@ $(LIBS) $(LINKFLAGS)
+
+$(OUTDIR)/compute_parents.exe: $(COMPUTE_PARENTS_OBJS)
 	$(LINK) $** -OUT:$@ $(LIBS) $(LINKFLAGS)
 
 {$(SOURCEDIR)}.cpp{$(OUTDIR)}.obj::


### PR DESCRIPTION
A new tool, compute_parents, takes a divide tree as input and produces a text file listing the prominence parent of every peak in the input.

See README for instructions on how to run compute_parents.