### PR TITLE
Fix bad empty pixel sentinel value.

### DIFF
--- a/code/pixel_array.h
+++ b/code/pixel_array.h
@@ -42,8 +42,9 @@ public:
     delete [] mPixels;
   }
 
-  // A non-terrain value
-  static const Pixel EmptyPixel = -32738;  
+  // A non-terrain value; also don't overlap with peak or saddle
+  // indexes.
+  static const Pixel EmptyPixel = std::numeric_limits<Pixel>::min();  
 
   Pixel get(int x, int y) const {
     return mPixels[y * mWidth + x];


### PR DESCRIPTION
With truly huge tiles, the bad sentinel value could actually be used as a saddle index, causing an infinite loop.