### PR TITLE
Cache first row and column of pixels from neighbors.

### DIFF
--- a/code/prominence.cpp
+++ b/code/prominence.cpp
@@ -204,8 +204,10 @@ int main(int argc, char **argv) {
   // Use double precision to avoid accumulating floating-point error during loop
   double lat = bounds[0];
   while (lat < bounds[1]) {
-    double lng = bounds[2];
-    while (lng < bounds[3]) {
+    // Go east-to-west to take advantage of some tile caching, since we need pixels
+    // from our eastern neighbor.
+    double lng = bounds[3];
+    while (lng >= bounds[2]) {
       // Allow specifying longitude ranges that span the antimeridian (lng > 180)
       auto wrappedLng = lng;
       if (!fileFormat.isUtm() && wrappedLng >= 180) {
@@ -227,7 +229,7 @@ int main(int argc, char **argv) {
             }));
       }
 
-      lng += fileFormat.degreesAcross();
+      lng -= fileFormat.degreesAcross();
     }
     lat += fileFormat.degreesAcross();
   }

--- a/code/tile_cache.h
+++ b/code/tile_cache.h
@@ -52,7 +52,15 @@ public:
   // If we've ever loaded the tile with the given minimum lat/lng, set elev to its maximum
   // elevation and return true, otherwise return false.
   bool getMaxElevation(double lat, double lng, Elevation *elev);
-  
+
+  // If we've ever loaded the tile with the given minimum lat/lng, set elevs to its
+  // first row and return true, otherwise return false.
+  bool getFirstRow(double lat, double lng, Elevation **elevs);
+
+  // If we've ever loaded the tile with the given minimum lat/lng, set elevs to its
+  // first column and return true, otherwise return false.
+  bool getFirstColumn(double lat, double lng, Elevation **elevs);
+
 private:
 
   Lock mLock;
@@ -61,9 +69,17 @@ private:
   // Map of encoded lat/lng to max elevation in that tile
   std::unordered_map<int, Elevation> mMaxElevations;
 
+  // Map of encoded lat/lng to first row/col in that tile.
+  // This is an optimization for the prominence algorithm.
+  typedef std::unordered_map<int, Elevation *> CachedElevations;
+  CachedElevations mFirstRows;
+  CachedElevations mFirstCols;
+
   Tile *loadInternal(double minLat, double minLng) const;
   
   int makeCacheKey(double minLat, double minLng) const;
+
+  bool getFirstRowOrCol(double lat, double lng, const CachedElevations &cache, Elevation **elevs);
 };
 
 #endif  // _TILE_CACHE_H_

--- a/code/tile_loading_policy.h
+++ b/code/tile_loading_policy.h
@@ -31,11 +31,16 @@
 
 #include <string>
 
+class TileCache;
+
 // Responsible for loading a tile given location.
 
 class TileLoadingPolicy {
 public:
   virtual Tile *loadTile(double minLat, double minLng) const = 0;
+
+  // Optionally get access to the tile cache
+  virtual void setTileCache(TileCache *cache) = 0;
 };
 
 
@@ -60,11 +65,14 @@ public:
 
   virtual Tile *loadTile(double minLat, double minLng) const;
 
+  virtual void setTileCache(TileCache *cache);
+
 private:
   std::string mDirectory;  // Directory for loading tiles
   FileFormat mFileFormat;  
   bool mNeighborEdgeLoadingEnabled;
   int mUtmZone;
+  TileCache *mTileCache;
 
   // Load tile without modifications
   Tile *loadInternal(double minLat, double minLng) const;


### PR DESCRIPTION
In a large prominence run, this can remove the need for 3/4 of the disk reads.

Also iterate east to west to get more cache hits, as we read our eastern neighbor for pixels.