### PR TITLE
Fix truncation to integer in output filenames.

### DIFF
--- a/code/prominence_task.cpp
+++ b/code/prominence_task.cpp
@@ -134,6 +134,6 @@ string ProminenceTask::getFilenamePrefix() const {
 }
 
 int ProminenceTask::fractionalDegree(double degree) const {
-  double excess = abs(degree - static_cast<int>(degree));
+  double excess = fabs(degree - static_cast<int>(degree));
   return static_cast<int>(std::round(100 * excess));
 }


### PR DESCRIPTION
On some systems, abs silently casts to int, causing all outputs to truncate their hundredths values to 0, overwriting each other.