### PR TITLE
Add "CUSTOM" input format for abitrary resolution.

### DIFF
--- a/code/file_format.h
+++ b/code/file_format.h
@@ -43,7 +43,7 @@ public:
     THREEDEP_1M,  // FLT file containing one-meter LIDAR from 3D Elevation Program (3DEP)
     GLO30,  // Copernicus GLO-30 30m data
     FABDEM, // Tree-free Copernicus GLO-30 30m data
-    LIDAR,  // FLT file converted from LIDAR, 0.1 arcsecond
+    CUSTOM, // FLT file with customizable resolution
   };
 
   FileFormat() = default;
@@ -53,16 +53,16 @@ public:
 
   // Return the number of samples in one row or column of the file format,
   // including any border samples.
-  int rawSamplesAcross() const;
+  virtual int rawSamplesAcross() const;
 
   // Return the number of samples in a tile after its loaded and the borders
   // have been modified.
-  int inMemorySamplesAcross() const;
+  virtual int inMemorySamplesAcross() const;
   
   // Return the degrees in lat or lng covered by one tile.
   // Note that this is the logical value (1 degree, 0.25 degree), not necessarily
   // the precise value covered, including border samples.
-  double degreesAcross() const;
+  virtual double degreesAcross() const;
 
   // Does this format use UTM coordinates rather than lat/lng?
   bool isUtm() const;
@@ -77,6 +77,34 @@ public:
   
 private:
   Value mValue;
+};
+
+// A file format where the size of the tile in degrees and samples
+// can be specified.  There must be an integer number of tiles per
+// degree.  The data is assumed to be in FLT format.
+class CustomFileFormat : public FileFormat {
+public:
+  CustomFileFormat(double degreesAcross, int samplesAcross) :
+      FileFormat(Value::CUSTOM),
+      mDegreesAcross(degreesAcross),
+      mSamplesAcross(samplesAcross) {
+  }
+
+  virtual int rawSamplesAcross() const {
+    return mSamplesAcross;
+  }
+
+  virtual int inMemorySamplesAcross() const {
+    return mSamplesAcross;
+  }
+  
+  virtual double degreesAcross() const {
+    return mDegreesAcross;
+  }
+
+private:
+  double mDegreesAcross;
+  int mSamplesAcross;
 };
 
 #endif  // _FILE_FORMAT_H_

--- a/code/flt_loader.cpp
+++ b/code/flt_loader.cpp
@@ -33,9 +33,9 @@ using std::string;
 // while NED19 uses some very negative value (< -1e38).
 static const float NED_NODATA_MIN_ELEVATION = -9998;
 
-FltLoader::FltLoader(const FileFormat &format, int utmZone) {
-  mFormat = format;
-  mUtmZone = utmZone;
+FltLoader::FltLoader(const FileFormat &format, int utmZone) :
+    mFormat(format),
+    mUtmZone(utmZone) {
 }
 
 Tile *FltLoader::loadTile(const std::string &directory, double minLat, double minLng) {
@@ -47,7 +47,7 @@ Tile *FltLoader::loadTile(const std::string &directory, double minLat, double mi
   case FileFormat::Value::NED13:
   case FileFormat::Value::NED19:
   case FileFormat::Value::THREEDEP_1M:
-  case FileFormat::Value::LIDAR:
+  case FileFormat::Value::CUSTOM:
     return loadFromFltFile(directory, minLat, minLng);
 
   default:
@@ -194,7 +194,7 @@ string FltLoader::getFltFilename(double minLat, double minLng, const FileFormat 
              fractionalDegree(minLng));
     break;
 
-  case FileFormat::Value::LIDAR:
+  case FileFormat::Value::CUSTOM:
     snprintf(buf, sizeof(buf), "tile_%02dx%02d_%03dx%02d.flt",
              static_cast<int>(upperLat),
              fractionalDegree(upperLat),

--- a/code/flt_loader.h
+++ b/code/flt_loader.h
@@ -43,7 +43,7 @@ public:
   virtual Tile *loadTile(const std::string &directory, double minLat, double minLng);
 
 private:
-  FileFormat mFormat;
+  const FileFormat &mFormat;
   int mUtmZone;  // For data in UTM coordinates
   
   Tile *loadFromNEDZipFileInternal(const std::string &directory, double minLat, double minLng);

--- a/code/hgt_loader.cpp
+++ b/code/hgt_loader.cpp
@@ -38,7 +38,7 @@ static uint16 swapByteOrder16(uint16 us) {
   return (us >> 8) | (us << 8);
 }
 
-HgtLoader::HgtLoader(FileFormat fileFormat) {
+HgtLoader::HgtLoader(const FileFormat &fileFormat) {
   switch (fileFormat.value()) {
   case FileFormat::Value::HGT:
     mTileSize = 1201;

--- a/code/hgt_loader.h
+++ b/code/hgt_loader.h
@@ -32,7 +32,7 @@
 
 class HgtLoader : public TileLoader {
 public:
-  explicit HgtLoader(FileFormat fileFormat);
+  explicit HgtLoader(const FileFormat &fileFormat);
   
   // minLat and minLng name the SW corner of the tile, in degrees
   virtual Tile *loadTile(const std::string &directory, double minLat, double minLng);

--- a/code/isolation_finder.cpp
+++ b/code/isolation_finder.cpp
@@ -36,11 +36,11 @@
 using std::vector;
 
 IsolationFinder::IsolationFinder(TileCache *cache, const Tile *tile,
-                                 const CoordinateSystem &coordinateSystem, FileFormat format) {
+                                 const CoordinateSystem &coordinateSystem, const FileFormat &format) :
+    mFormat(format) {
   mTile = tile;
   mCache = cache;
   mCoordinateSystem = std::unique_ptr<CoordinateSystem>(coordinateSystem.clone());
-  mFormat = format;
 }
 
 IsolationRecord IsolationFinder::findIsolation(Offsets peak) const {

--- a/code/isolation_finder.h
+++ b/code/isolation_finder.h
@@ -60,7 +60,7 @@ struct IsolationRecord {
 class IsolationFinder {
 public:
   IsolationFinder(TileCache *cache, const Tile *tile,
-                  const CoordinateSystem &coordinateSystem, FileFormat format);
+                  const CoordinateSystem &coordinateSystem, const FileFormat &format);
   
   IsolationRecord findIsolation(Offsets peak) const;
   
@@ -69,7 +69,7 @@ private:
   const Tile *mTile;
   TileCache *mCache;
   std::unique_ptr<CoordinateSystem> mCoordinateSystem;
-  FileFormat mFormat;
+  const FileFormat &mFormat;
 
   // Search tile for a point higher than seedElevation.
   //

--- a/code/tile_loading_policy.cpp
+++ b/code/tile_loading_policy.cpp
@@ -87,7 +87,7 @@ Tile *BasicTileLoadingPolicy::loadTile(double minLat, double minLng) const {
       break;
 
     case FileFormat::Value::GLO30:  // fall through
-    case FileFormat::Value::LIDAR:
+    case FileFormat::Value::CUSTOM:
     case FileFormat::Value::FABDEM: {
       // GLO30 "helpfully" removes the last row and column from each tile,
       // so we need to stick them back on.
@@ -126,7 +126,7 @@ Tile *BasicTileLoadingPolicy::loadInternal(double minLat, double minLng) const {
   case FileFormat::Value::NED19:
   case FileFormat::Value::NED1_ZIP:
   case FileFormat::Value::THREEDEP_1M:
-  case FileFormat::Value::LIDAR:
+  case FileFormat::Value::CUSTOM:
     loader = new FltLoader(mFileFormat, mUtmZone);
     break;
     

--- a/code/tile_loading_policy.h
+++ b/code/tile_loading_policy.h
@@ -69,7 +69,7 @@ public:
 
 private:
   std::string mDirectory;  // Directory for loading tiles
-  FileFormat mFileFormat;  
+  const FileFormat &mFileFormat;  
   bool mNeighborEdgeLoadingEnabled;
   int mUtmZone;
   TileCache *mTileCache;

--- a/scripts/run_lidar_prominence.py
+++ b/scripts/run_lidar_prominence.py
@@ -23,10 +23,6 @@ from pathlib import Path
 
 from boundary import Boundary
 
-# Each output tile is this many degrees and samples on a side
-TILE_SIZE_DEGREES = 0.1  # Must divide 1 evenly
-TILE_SIZE_SAMPLES = 10000
-
 epsilon = 0.0001
 
 def run_command(command_string):
@@ -40,20 +36,20 @@ def maybe_create_directory(dir_name):
     if not os.path.isdir(dir_name):
         print(f"Couldn't create directory {dir_name}")
     
-def round_down(coord):
-    """Return coord rounded down to the nearest TILE_SIZE_DEGREES"""
-    return math.floor(coord / TILE_SIZE_DEGREES) * TILE_SIZE_DEGREES
+def round_down(coord, interval):
+    """Return coord rounded down to the nearest interval"""
+    return math.floor(coord / interval) * interval
 
-def round_up(coord):
-    """Return coord rounded up to the nearest TILE_SIZE_DEGREES"""
-    return math.ceil(coord / TILE_SIZE_DEGREES) * TILE_SIZE_DEGREES
+def round_up(coord, interval):
+    """Return coord rounded up to the nearest interval"""
+    return math.ceil(coord / interval) * interval
 
 def sign(a):
     return bool(a > 0) - bool(a < 0)
 
-def filename_for_coordinates(x, y):
+def filename_for_coordinates(x, y, degrees_per_tile):
     """Return output filename for the given coordinates"""
-    y += TILE_SIZE_DEGREES  # Name uses upper left corner
+    y += degrees_per_tile  # Name uses upper left corner
     xpart = int(round(x * 100))
     ypart = int(round(y * 100))
 
@@ -182,14 +178,14 @@ def create_vrts(tile_dir, input_files, skip_boundary):
 @handle_ctrl_c
 def process_tile(args):
     """scale is multiplied by each input value"""
-    (x, y, vrt_filename, output_filename, scale) = args
+    (x, y, vrt_filename, output_filename, scale, degrees_per_tile, samples_per_tile) = args
     print(f"Processing {x:.2f}, {y:.2f}")
     gdal.UseExceptions()
 
     translate_options = gdal.TranslateOptions(
         format = "EHdr",
-        width = TILE_SIZE_SAMPLES, height = TILE_SIZE_SAMPLES,
-        projWin = [x, y + TILE_SIZE_DEGREES, x + TILE_SIZE_DEGREES, y],
+        width = samples_per_tile, height = samples_per_tile,
+        projWin = [x, y + degrees_per_tile, x + degrees_per_tile, y],
         noData = -999999,
         scaleParams = [[-30000, 30000, -30000*scale, 30000*scale]],
         callback=gdal.TermProgress_nocb)
@@ -197,7 +193,6 @@ def process_tile(args):
 
 def main():
     parser = argparse.ArgumentParser(description='Convert LIDAR to standard tiles')
-    requiredNamed = parser.add_argument_group('required named arguments')
     parser.add_argument('--input_units', choices=['feet', 'meters'],
                         default='meters',
                         help="Elevation units in input files")
@@ -220,6 +215,10 @@ def main():
                         help='Input Lidar tiles, or GDAL VRT of tiles')
     parser.add_argument('--boundary',
                         help="Precomputed shp file with boundary of input data")
+    parser.add_argument('--degrees_per_tile', type=float, default=0.1,
+                        help='Size of reprojected tiles to generate')
+    parser.add_argument('--samples_per_tile', type=int, default=10000,
+                        help='Number of samples per edge of a reprojected tile')
     args = parser.parse_args()
 
     gdal.UseExceptions()
@@ -256,10 +255,10 @@ def main():
     xmin, xmax, ymin, ymax = bounds.GetEnvelope()
 
     # Rounded to tile degree boundaries so that we cover the whole data set
-    xmin = round_down(xmin)
-    ymin = round_down(ymin)
-    xmax = round_up(xmax)
-    ymax = round_up(ymax)
+    xmin = round_down(xmin, args.degrees_per_tile)
+    ymin = round_down(ymin, args.degrees_per_tile)
+    xmax = round_up(xmax, args.degrees_per_tile)
+    ymax = round_up(ymax, args.degrees_per_tile)
 
     # Run in parallel
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -273,19 +272,20 @@ def main():
         x = xmin
         while x <= xmax - epsilon:
             # Skip this tile if it doesn't overlap any data in the source
-            polybox = polygon_for_tile(x, y, TILE_SIZE_DEGREES, TILE_SIZE_DEGREES)
+            polybox = polygon_for_tile(x, y, args.degrees_per_tile, args.degrees_per_tile)
             if args.skip_boundary or polybox.Intersects(bounds):
-                output_filename = os.path.join(args.tile_dir, filename_for_coordinates(x, y))
+                output_filename = os.path.join(args.tile_dir, filename_for_coordinates(x, y, args.degrees_per_tile))
                 # If input is in feet, will need to scale tile to meters
                 if args.input_units == "feet":
                     scale = 0.3048
                 else:
                     scale = 1
 
-                process_args.append((x, y, warped_vrt_filename, output_filename, scale))
+                process_args.append((x, y, warped_vrt_filename, output_filename, scale,
+                                     args.degrees_per_tile, args.samples_per_tile))
             
-            x += TILE_SIZE_DEGREES
-        y += TILE_SIZE_DEGREES
+            x += args.degrees_per_tile
+        y += args.degrees_per_tile
 
     results = pool.map(process_tile, process_args)
     if any(map(lambda x: isinstance(x, KeyboardInterrupt), results)):
@@ -298,7 +298,8 @@ def main():
     # Run prominence and merge_divide_trees
     print("Running prominence")
     prominence_binary = os.path.join(args.binary_dir, "prominence")
-    prom_command = f"{prominence_binary} --v=1 -f LIDAR -i {args.tile_dir} -o {args.output_dir}" + \
+    prom_command = f"{prominence_binary} --v=1 -f CUSTOM-{args.degrees_per_tile}-{args.samples_per_tile}" + \
+        f" -i {args.tile_dir} -o {args.output_dir}" + \
         f" -t {args.threads} -m {args.min_prominence}" + \
         f" -- {ymin} {ymax} {xmin} {xmax}"
     run_command(prom_command)

--- a/scripts/run_prominence.py
+++ b/scripts/run_prominence.py
@@ -1,4 +1,4 @@
-# Processes a set of Lidar tiles:
+# Processes a set of raster tiles:
 # - Converts them to lat-long projection
 # - Resamples to tiles that are of fixed size and resolution, with elevations in meters
 #
@@ -192,7 +192,7 @@ def process_tile(args):
     gdal.Translate(output_filename, vrt_filename, options = translate_options)
 
 def main():
-    parser = argparse.ArgumentParser(description='Convert LIDAR to standard tiles')
+    parser = argparse.ArgumentParser(description='Reproject arbitrary rasters to a fixed grid and compute prominence')
     parser.add_argument('--input_units', choices=['feet', 'meters'],
                         default='meters',
                         help="Elevation units in input files")
@@ -223,6 +223,12 @@ def main():
 
     gdal.UseExceptions()
 
+    # Valudate degrees per tile; it must divide 1 degree evenly
+    tiles_per_degree = 1 / args.degrees_per_tile
+    if abs(int(tiles_per_degree) - tiles_per_degree) > 0.001:
+        print("tiles_per_degree must divide 1 degree evenly")
+        exit(1)
+    
     # Create missing directories
     maybe_create_directory(args.output_dir)
     maybe_create_directory(args.tile_dir)


### PR DESCRIPTION
This format allows the intermediate tile size and resolution to be specified, so arbitrary data can be reprojected efficiently. The default is 0.1 degrees per side with 10000 samples per side, which corresponds roughly to 1m data.

This replaces the "LIDAR" format.