### PR TITLE
Make sure tiles produced by `run_prominence.py` have correct data type

### DIFF
--- a/scripts/run_prominence.py
+++ b/scripts/run_prominence.py
@@ -189,6 +189,7 @@ def process_tile(args):
 
     translate_options = gdal.TranslateOptions(
         format = "EHdr",
+        outputType=gdal.GDT_Float32,
         width = samples_per_tile, height = samples_per_tile,
         projWin = [x, y + degrees_per_tile, x + degrees_per_tile, y],
         noData = -999999,


### PR DESCRIPTION
Hi,

when running `run_prominence.py` with custom data, creating the tiles could preserve (incompatible) data types from the source files. This happens for example when running it on SRTM tiles downloaded from here https://dwtkns.com/srtm/, which come as Int16.

Explicitly setting the data type in the call to gdal translate could solve this. Some of the other `*_prominence.py` scripts already apply the same option.

Kind regards
Andreas