### PR TITLE
Fix lat and lng filenames near 0 for Lidar

### DIFF
--- a/code/flt_loader.cpp
+++ b/code/flt_loader.cpp
@@ -196,11 +196,13 @@ string FltLoader::getFltFilename(double minLat, double minLng, const FileFormat 
 
   case FileFormat::Value::CUSTOM: {
     int upperLatInt = static_cast<int>(upperLat);  // Watch out for "minus 0"
-    snprintf(buf, sizeof(buf), "tile_%s%02dx%02d_%03dx%02d.flt",
+    int minLngInt = static_cast<int>(minLng);
+    snprintf(buf, sizeof(buf), "tile_%s%02dx%02d_%s%03dx%02d.flt",
              (upperLatInt >= 0) ? "" : "-",
              abs(upperLatInt),
              fractionalDegree(upperLat),
-             static_cast<int>(minLng),
+             (minLng >= 0) ? "" : "-",
+             abs(minLngInt),
              fractionalDegree(minLng));
     break;
   }

--- a/code/prominence_task.cpp
+++ b/code/prominence_task.cpp
@@ -127,9 +127,11 @@ string ProminenceTask::getFilenamePrefix() const {
 
   int latHundredths = fractionalDegree(lat);
   int lngHundredths = fractionalDegree(lng);
-  snprintf(filename, sizeof(filename), "prominence-%02dx%02d-%03dx%02d",
-           static_cast<int>(lat), latHundredths,
-           static_cast<int>(lng), lngHundredths);
+  snprintf(filename, sizeof(filename), "prominence-%s%02dx%02d-%s%03dx%02d",
+           (lat >= 0) ? "" : "-",
+           static_cast<int>(abs(lat)), latHundredths,
+           (lng >= 0) ? "" : "-",
+           static_cast<int>(abs(lng)), lngHundredths);
   return mOptions.outputDir + "/" + filename;
 }
 

--- a/code/tile_loading_policy.cpp
+++ b/code/tile_loading_policy.cpp
@@ -111,7 +111,7 @@ Tile *BasicTileLoadingPolicy::loadInternal(double minLat, double minLng) const {
 
   // If the lat/lng can't be represented exactly in floating point,
   // there's sometimes roundoff error when converting to integers for
-  // tile filenames.  Adding a little slop prevents truncation.  
+  // tile filenames.  Adding a little slop prevents truncation.
   minLat = adjustCoordinate(minLat);
   minLng = adjustCoordinate(minLng);
 

--- a/code/util.cpp
+++ b/code/util.cpp
@@ -48,7 +48,7 @@ double adjustCoordinate(double coordinate) {
   // A tile is not going to be smaller than 0.1 degrees or so, so this
   // amount should be safe.
   const double epsilon = 0.001;
-  return coordinate + ((coordinate >= 0) ? epsilon : -epsilon);
+  return coordinate + ((coordinate >= -1e-8) ? epsilon : -epsilon);
 }
 
 string trim(const string &s) {

--- a/scripts/run_prominence.py
+++ b/scripts/run_prominence.py
@@ -55,7 +55,7 @@ def filename_for_coordinates(x, y, degrees_per_tile):
     x_fraction = abs(xpart) % 100
     y_fraction = abs(ypart) % 100
 
-    # Handle "-0.1" -> "-00x10"
+    # Handle "-0.1" -> "-000x10"
     if xpart < 0:
         x_string = f"-{abs(x_int):03d}"
     else:

--- a/scripts/run_prominence.py
+++ b/scripts/run_prominence.py
@@ -57,7 +57,7 @@ def filename_for_coordinates(x, y, degrees_per_tile):
 
     # Handle "-0.1" -> "-00x10"
     if xpart < 0:
-        x_string = f"-{abs(x_int):02d}"
+        x_string = f"-{abs(x_int):03d}"
     else:
         x_string = f"{x_int:03d}"
     x_string +=  f"x{x_fraction:02d}"


### PR DESCRIPTION
Incorrect filenames were being generated near the
equator and meridian when running in high-resolution (Lidar) mode.