### PR TITLE
Reduce flood-fills from two to one

### DIFF
--- a/code/domain_map.cpp
+++ b/code/domain_map.cpp
@@ -38,15 +38,18 @@ DomainMap::DomainMap(const Tile *tile) :
   mPixels.setAllPixels(EmptyPixel);
  }
 
-void DomainMap::findFlatArea(int x, int y, Boundary *boundary) {
+void DomainMap::findFlatArea(int x, int y, Boundary *boundary, std::vector<Range> *ranges) {
   // Use a new marker value so we don't see the results of any previous operations
   mMarkerValue += 1;
   boundary->higherPoints.clear();
+  if (ranges != nullptr) {
+    ranges->clear();
+  }
 
   Elevation elev = mTile->get(x, y);
 
   // Flood fill
-  mPendingRanges.push_back(Range(x, x, y));
+  mPendingRanges.push_back({x, x, y});
   
   while (!mPendingRanges.empty()) {
     Range range(mPendingRanges.back());
@@ -90,6 +93,9 @@ void DomainMap::findFlatArea(int x, int y, Boundary *boundary) {
 
     // Mark range as visited
     mMarkers.setRange(range.xmin, range.y, mMarkerValue, range.xmax - range.xmin + 1);
+    if (ranges != nullptr) {
+      ranges->push_back(range);
+    }
 
     // Find adjacent ranges above
     if (range.y > 0) {
@@ -112,7 +118,7 @@ void DomainMap::findFlatArea(int x, int y, Boundary *boundary) {
               // It's enough to check the leftmost pixel, since the whole
               // range is either empty or non-empty.
               if (mMarkers.get(lo, topy) != mMarkerValue) {
-                mPendingRanges.push_back(Range(lo, topx - 1, topy));
+                mPendingRanges.push_back({lo, topx - 1, topy});
               }
               lo = -1;
             }
@@ -121,7 +127,7 @@ void DomainMap::findFlatArea(int x, int y, Boundary *boundary) {
       }
       // Didn't encounter end of range
       if (lo != -1 && mMarkers.get(lo, topy) != mMarkerValue) {
-        mPendingRanges.push_back(Range(lo, maxx, topy));
+        mPendingRanges.push_back({lo, maxx, topy});
       }
     }
 
@@ -146,7 +152,7 @@ void DomainMap::findFlatArea(int x, int y, Boundary *boundary) {
               // It's enough to check the leftmost pixel, since the whole
               // range is either empty or non-empty.
               if (mMarkers.get(lo, bottomy) != mMarkerValue) {
-                mPendingRanges.push_back(Range(lo, bottomx - 1, bottomy));
+                mPendingRanges.push_back({lo, bottomx - 1, bottomy});
               }
               lo = -1;
             }
@@ -155,94 +161,15 @@ void DomainMap::findFlatArea(int x, int y, Boundary *boundary) {
       }
       // Didn't encounter end of range
       if (lo != -1 && mMarkers.get(lo, bottomy) != mMarkerValue) {
-        mPendingRanges.push_back(Range(lo, maxx, bottomy));
+        mPendingRanges.push_back({lo, maxx, bottomy});
       }
     }
   }
 }
 
-void DomainMap::fillFlatArea(int x, int y, Pixel value) {
-  // Flood fill based on horizontal ranges
-  Elevation elev = mTile->get(x, y);
-
-  mPendingRanges.push_back(Range(x, x, y));
-  
-  while (!mPendingRanges.empty()) {
-    Range range(mPendingRanges.back());
-    mPendingRanges.pop_back();
-
-    // Extend range to the left
-    while (true) {
-      Coord leftx = range.xmin - 1;
-      if (leftx < 0 || mTile->get(leftx, range.y) != elev) {
-        break;
-      }
-      range.xmin = leftx;
-    }
-
-    // Extend range to the right
-    while (true) {
-      Coord rightx = range.xmax + 1;
-      if (rightx >= mTile->width() || mTile->get(rightx, range.y) != elev) {
-        break;
-      }
-      range.xmax = rightx;
-    }
-
-    // Fill range
+void DomainMap::fillFlatArea(const std::vector<Range> &ranges, Pixel value) {
+  for (const Range &range : ranges) {
     mPixels.setRange(range.xmin, range.y, value, range.xmax - range.xmin + 1);
-
-    // Find adjacent ranges above
-    if (range.y > 0) {
-      Coord lo = -1;
-      Coord topy = range.y - 1;
-      for (Coord topx = range.xmin - 1; topx <= range.xmax + 1; ++topx) {
-        if (!mTile->isInExtents(topx, topy) || mTile->get(topx, topy) != elev) {
-          if (lo != -1) {
-            // End of a range.  Add it if it hasn't been filled before.
-            // It's enough to check the leftmost pixel, since the whole
-            // range is either empty or non-empty.
-            if (mPixels.get(lo, topy) == EmptyPixel) {
-              mPendingRanges.push_back(Range(lo, topx - 1, topy));
-            }
-            lo = -1;
-          }
-        } else {
-          if (lo == -1) {
-            lo = topx;  // start of a range
-          }
-        }
-      }
-      // Didn't encounter end of range
-      if (lo != -1 && mPixels.get(lo, topy) == EmptyPixel) {
-        mPendingRanges.push_back(Range(lo, range.xmax + 1, topy));
-      }
-    }
-
-    // Find adjacent ranges below
-    if (range.y < mTile->height() - 1) {
-      Coord lo = -1;
-      Coord bottomy = range.y + 1;
-      for (Coord bottomx = range.xmin - 1; bottomx <= range.xmax + 1; ++bottomx) {
-        if (!mTile->isInExtents(bottomx, bottomy) || mTile->get(bottomx, bottomy) != elev) {
-          if (lo != -1) {
-            // End of a range
-            if (mPixels.get(lo, bottomy) == EmptyPixel) {
-              mPendingRanges.push_back(Range(lo, bottomx - 1, bottomy));
-            }
-            lo = -1;
-          }
-        } else {
-          if (lo == -1) {
-            lo = bottomx;  // start of a range
-          }
-        }
-      }
-      // Didn't encounter end of range
-      if (lo != -1 && mPixels.get(lo, bottomy) == EmptyPixel) {
-        mPendingRanges.push_back(Range(lo, range.xmax + 1, bottomy));
-      }
-    }
   }
 }
 

--- a/code/domain_map.h
+++ b/code/domain_map.h
@@ -40,6 +40,13 @@
 
 #include <vector>
 
+// A Range is the set of pixels at [xmin,y] through [xmax,y] inclusive.
+// All pixels in a Range are known to be at the target elevation and are marked.
+struct Range {
+  Coord xmin, xmax;
+  Coord y;
+};
+
 class DomainMap {
 public:
   explicit DomainMap(const Tile *tile);
@@ -58,11 +65,12 @@ public:
   // Find the flat region containing the given point, then fills in
   // boundary with the points on the boundary higher than the given
   // point.  A given point may appear in the boundary multiple times.
-  void findFlatArea(int x, int y, Boundary *boundary);
+  // ranges, if non-null, is filled in with the flat region's extent.
+  void findFlatArea(int x, int y, Boundary *boundary, std::vector<Range> *ranges);
 
-  // Fill the 8-connected flat region at (x, y) with the given value.
-  void fillFlatArea(int x, int y, Pixel value);
-  
+  // Fill the given ranges with the given value
+  void fillFlatArea(const std::vector<Range> &ranges, Pixel value);
+
   Pixel get(Offsets offsets) const {
     return get(offsets.x(), offsets.y());
   }
@@ -85,19 +93,6 @@ private:
 
   // An unused marker value for use during the next operation
   int mMarkerValue;  
-
-  // A Range is the set of pixels at [xmin,y] through [xmax,y] inclusive.
-  // All pixels in a Range are known to be at the target elevation and are marked.
-  struct Range {
-    Range(Coord minx, Coord maxx, Coord ycoord) {
-      xmin = minx;
-      xmax = maxx;
-      y = ycoord;
-    }
-    
-    Coord xmin, xmax;
-    Coord y;
-  };
 
   std::vector<Range> mPendingRanges;
 };

--- a/code/tree_builder.cpp
+++ b/code/tree_builder.cpp
@@ -79,6 +79,7 @@ void TreeBuilder::findExtrema() {
   bool vlog4 = VLOG_IS_ON(4);
   
   DomainMap::Boundary boundary;
+  vector<Range> ranges;
   vector<Offsets> segmentHighPoints;
   for (int y = 0; y < mTile->height(); ++y) {
     for (int x = 0; x < mTile->width(); ++x) {
@@ -94,12 +95,12 @@ void TreeBuilder::findExtrema() {
         continue;
       }
 
-      mDomainMap.findFlatArea(x, y, &boundary);
+      mDomainMap.findFlatArea(x, y, &boundary, &ranges);
       
       // If no higher boundary points, this is a peak
       if (boundary.higherPoints.empty()) {
         int peakId = static_cast<int>(mPeaks.size() + 1);
-        mDomainMap.fillFlatArea(x, y, peakId);
+        mDomainMap.fillFlatArea(ranges, peakId);
         
         // TODO: Pick a point near the middle of the flat region
         mPeaks.push_back(Peak(Offsets(x, y), elev));
@@ -115,7 +116,7 @@ void TreeBuilder::findExtrema() {
       // Look for saddles
       // Quick reject: can't be a saddle if there's only 1 higher point
       if (boundary.higherPoints.size() < 2) {
-        mDomainMap.fillFlatArea(x, y, DomainMap::GenericFlatArea);
+        mDomainMap.fillFlatArea(ranges, DomainMap::GenericFlatArea);
         continue;
       }
 
@@ -200,7 +201,7 @@ void TreeBuilder::findExtrema() {
           VLOG(4) << "Rejecting flat area " << x << " " << y
                   << " elev " << elev << " multiplicity " << numSegments;
         }
-        mDomainMap.fillFlatArea(x, y, DomainMap::GenericFlatArea);
+        mDomainMap.fillFlatArea(ranges, DomainMap::GenericFlatArea);
         continue;
       }
 
@@ -214,7 +215,7 @@ void TreeBuilder::findExtrema() {
 
           // Mark flat area; only need to do this once, and which saddle ID to use is arbitrary
           if (filledSaddleId == 0) {
-            mDomainMap.fillFlatArea(x, y, saddleId);
+            mDomainMap.fillFlatArea(ranges, saddleId);
             filledSaddleId = saddleId;
           }
 
@@ -426,7 +427,7 @@ vector<Offsets> TreeBuilder::walkUpToPeak(Offsets startPoint) {
     if (point == newPoint) {
       // No higher neighbor; need to check boundary of entire flat area
       DomainMap::Boundary boundary;
-      mDomainMap.findFlatArea(point.x(), point.y(), &boundary);
+      mDomainMap.findFlatArea(point.x(), point.y(), &boundary, nullptr);
 
       Elevation highestElevation = mTile->get(point);
       for (auto value : boundary.higherPoints) {


### PR DESCRIPTION
Save the result of the flat area calculation, and then use it for the following flood fill.  Saves second computation of the flat area.